### PR TITLE
ipfs migration to boxo

### DIFF
--- a/dir.go
+++ b/dir.go
@@ -11,7 +11,7 @@ import (
 
 	ft "github.com/bittorrent/go-unixfs"
 	uio "github.com/bittorrent/go-unixfs/io"
-	dag "github.com/ipfs/go-merkledag"
+	dag "github.com/ipfs/boxo/ipld/merkledag"
 
 	cid "github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"

--- a/file.go
+++ b/file.go
@@ -7,7 +7,7 @@ import (
 
 	ft "github.com/bittorrent/go-unixfs"
 	mod "github.com/bittorrent/go-unixfs/mod"
-	dag "github.com/ipfs/go-merkledag"
+	dag "github.com/ipfs/boxo/ipld/merkledag"
 
 	chunker "github.com/bittorrent/go-btfs-chunker"
 	ipld "github.com/ipfs/go-ipld-format"

--- a/root.go
+++ b/root.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	ft "github.com/bittorrent/go-unixfs"
-	dag "github.com/ipfs/go-merkledag"
+	dag "github.com/ipfs/boxo/ipld/merkledag"
 
 	ipld "github.com/ipfs/go-ipld-format"
 	logging "github.com/ipfs/go-log"


### PR DESCRIPTION
As part of the IPFS SDK dependencies migration to boxo, this update is necessary to move to boxo SDK for BTFS. I'll be doing other Pull Request in several BTFS repos to safely move to boxo and support newer golang releases